### PR TITLE
Refactor Home feature to use reactive streams with RxJava3

### DIFF
--- a/app/src/main/java/com/example/recipe_android_project/features/home/data/datasource/remote/HomeRemoteDatasource.java
+++ b/app/src/main/java/com/example/recipe_android_project/features/home/data/datasource/remote/HomeRemoteDatasource.java
@@ -1,9 +1,11 @@
 package com.example.recipe_android_project.features.home.data.datasource.remote;
+
 import com.example.recipe_android_project.core.config.RetrofitClient;
 import com.example.recipe_android_project.features.home.data.dto.category.CategoryResponseDto;
-import com.example.recipe_android_project.features.search.data.dto.filter_result.FilterResultResponseDto;
 import com.example.recipe_android_project.features.home.data.dto.meal.MealResponseDto;
-import retrofit2.Call;
+import com.example.recipe_android_project.features.search.data.dto.filter_result.FilterResultResponseDto;
+
+import io.reactivex.rxjava3.core.Single;
 
 public class HomeRemoteDatasource {
 
@@ -13,23 +15,27 @@ public class HomeRemoteDatasource {
         this.mealApiService = RetrofitClient.getMealApiService();
     }
 
-    public Call<MealResponseDto> getMealOfTheDayCall() {
+    public HomeRemoteDatasource(MealApiService mealApiService) {
+        this.mealApiService = mealApiService;
+    }
+
+    public Single<MealResponseDto> getMealOfTheDay() {
         return mealApiService.getRandomMeal();
     }
 
-    public Call<CategoryResponseDto> getCategoriesCall() {
+    public Single<CategoryResponseDto> getCategories() {
         return mealApiService.getCategories();
     }
 
-    public Call<MealResponseDto> getMealsByFirstLetterCall(String firstLetter) {
+    public Single<MealResponseDto> getMealsByFirstLetter(String firstLetter) {
         return mealApiService.getMealsByFirstLetter(firstLetter);
     }
 
-    public Call<FilterResultResponseDto> getMealsByCategoryCall(String categoryName) {
+    public Single<FilterResultResponseDto> getMealsByCategory(String categoryName) {
         return mealApiService.filterByMealCategory(categoryName);
     }
 
-    public Call<MealResponseDto> getMealByIdCall(String id) {
+    public Single<MealResponseDto> getMealById(String id) {
         return mealApiService.getMealById(id);
     }
 }

--- a/app/src/main/java/com/example/recipe_android_project/features/home/data/datasource/remote/MealApiService.java
+++ b/app/src/main/java/com/example/recipe_android_project/features/home/data/datasource/remote/MealApiService.java
@@ -5,23 +5,27 @@ import com.example.recipe_android_project.features.home.data.dto.category.Catego
 import com.example.recipe_android_project.features.home.data.dto.meal.MealResponseDto;
 import com.example.recipe_android_project.features.search.data.dto.filter_result.FilterResultResponseDto;
 
-import retrofit2.Call;
+import io.reactivex.rxjava3.core.Single;
 import retrofit2.http.GET;
 import retrofit2.http.Query;
 
 public interface MealApiService {
+
     @GET("random.php")
-    Call<MealResponseDto> getRandomMeal();
+    Single<MealResponseDto> getRandomMeal();
+
     @GET("lookup.php")
-    Call<MealResponseDto> getMealById(@Query("i") String id);
+    Single<MealResponseDto> getMealById(@Query("i") String id);
+
     @GET("categories.php")
-    Call<CategoryResponseDto> getCategories();
+    Single<CategoryResponseDto> getCategories();
 
     @GET("list.php")
-    Call<CategoryResponseDto> getCategoryList(@Query("l") String list);
+    Single<CategoryResponseDto> getCategoryList(@Query("l") String list);
+
     @GET("search.php")
-    Call<MealResponseDto> getMealsByFirstLetter(@Query("f") String firstLetter);
+    Single<MealResponseDto> getMealsByFirstLetter(@Query("f") String firstLetter);
 
     @GET("filter.php")
-    Call<FilterResultResponseDto> filterByMealCategory(@Query("c") String category);
+    Single<FilterResultResponseDto> filterByMealCategory(@Query("c") String category);
 }

--- a/app/src/main/java/com/example/recipe_android_project/features/home/data/repository/HomeRepository.java
+++ b/app/src/main/java/com/example/recipe_android_project/features/home/data/repository/HomeRepository.java
@@ -1,25 +1,17 @@
 package com.example.recipe_android_project.features.home.data.repository;
 
-import com.example.recipe_android_project.core.config.ResultCallback;
 import com.example.recipe_android_project.features.home.data.datasource.remote.HomeRemoteDatasource;
-import com.example.recipe_android_project.features.home.data.dto.category.CategoryDto;
-import com.example.recipe_android_project.features.home.data.dto.category.CategoryResponseDto;
-import com.example.recipe_android_project.features.home.data.dto.meal.MealDto;
-import com.example.recipe_android_project.features.home.data.dto.meal.MealResponseDto;
 import com.example.recipe_android_project.features.home.data.mapper.CategoryMapper;
 import com.example.recipe_android_project.features.home.data.mapper.MealMapper;
 import com.example.recipe_android_project.features.home.model.Category;
 import com.example.recipe_android_project.features.home.model.Meal;
-import com.example.recipe_android_project.features.search.data.dto.filter_result.FilterResultResponseDto;
 import com.example.recipe_android_project.features.search.data.mapper.FilterResultMapper;
 import com.example.recipe_android_project.features.search.domain.model.FilterResult;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import retrofit2.Call;
-import retrofit2.Callback;
-import retrofit2.Response;
+import io.reactivex.rxjava3.core.Single;
 
 public class HomeRepository {
 
@@ -28,109 +20,64 @@ public class HomeRepository {
     public HomeRepository() {
         this.remote = new HomeRemoteDatasource();
     }
-    public void getMealOfTheDay(ResultCallback<Meal> callback) {
-        remote.getMealOfTheDayCall().enqueue(new Callback<MealResponseDto>() {
-            @Override
-            public void onResponse(Call<MealResponseDto> call, Response<MealResponseDto> response) {
-                if (response.isSuccessful() && response.body() != null) {
 
-                    List<MealDto> mealsDto = response.body().getMeals();
-                    if (mealsDto == null || mealsDto.isEmpty()) {
-                        callback.onError(new Exception("No meal found."));
-                        return;
+    public HomeRepository(HomeRemoteDatasource remote) {
+        this.remote = remote;
+    }
+
+    public Single<Meal> getMealOfTheDay() {
+        return remote.getMealOfTheDay()
+                .flatMap(response -> {
+                    if (response == null || response.getMeals() == null || response.getMeals().isEmpty()) {
+                        return Single.error(new Exception("No meal found."));
                     }
-
-                    Meal meal = MealMapper.toDomain(mealsDto.get(0));
+                    Meal meal = MealMapper.toDomain(response.getMeals().get(0));
                     if (meal == null) {
-                        callback.onError(new Exception("Meal mapping failed."));
-                        return;
+                        return Single.error(new Exception("Meal mapping failed."));
                     }
-
-                    callback.onSuccess(meal);
-
-                } else {
-                    callback.onError(new Exception("Request failed: " + response.code()));
-                }
-            }
-
-            @Override
-            public void onFailure(Call<MealResponseDto> call, Throwable t) {
-                callback.onError(new Exception(t));
-            }
-        });
+                    return Single.just(meal);
+                });
     }
 
-
-    public void getCategories(ResultCallback<List<Category>> callback) {
-        remote.getCategoriesCall().enqueue(new Callback<CategoryResponseDto>() {
-            @Override
-            public void onResponse(Call<CategoryResponseDto> call, Response<CategoryResponseDto> response) {
-                if (response.isSuccessful() && response.body() != null) {
-                    List<CategoryDto> dtos =
-                            response.body().getCategories();
-                    List<Category> categories = CategoryMapper.toDomainList(dtos);
-                    callback.onSuccess(categories);
-
-                } else {
-                    callback.onError(new Exception("Request failed: " + response.code()));
-                }
-            }
-
-            @Override
-            public void onFailure(Call<CategoryResponseDto> call, Throwable t) {
-                callback.onError(new Exception(t));
-            }
-        });
+    public Single<List<Category>> getCategories() {
+        return remote.getCategories()
+                .map(response -> {
+                    if (response == null || response.getCategories() == null) {
+                        return new ArrayList<Category>();
+                    }
+                    return CategoryMapper.toDomainList(response.getCategories());
+                });
     }
 
-    public void getMealsByFirstLetter(String firstLetter, ResultCallback<List<Meal>> callback) {
+    public Single<List<Meal>> getMealsByFirstLetter(String firstLetter) {
         if (firstLetter == null || firstLetter.trim().isEmpty()) {
-            callback.onError(new IllegalArgumentException("firstLetter is required"));
-            return;
+            return Single.error(new IllegalArgumentException("firstLetter is required"));
         }
 
         String f = firstLetter.trim().substring(0, 1);
 
-        remote.getMealsByFirstLetterCall(f).enqueue(new Callback<MealResponseDto>() {
-            @Override
-            public void onResponse(Call<MealResponseDto> call, Response<MealResponseDto> response) {
-                if (response.isSuccessful() && response.body() != null) {
-
-                    List<com.example.recipe_android_project.features.home.data.dto.meal.MealDto> dtos =
-                            response.body().getMeals();
-
-                    List<Meal> meals = MealMapper.toDomainList(dtos);
-
-                    callback.onSuccess(meals);
-
-                } else {
-                    callback.onError(new Exception("Request failed: " + response.code()));
-                }
-            }
-
-            @Override
-            public void onFailure(Call<MealResponseDto> call, Throwable t) {
-                callback.onError(new Exception(t));
-            }
-        });
+        return remote.getMealsByFirstLetter(f)
+                .map(response -> {
+                    if (response == null || response.getMeals() == null) {
+                        return new ArrayList<Meal>();
+                    }
+                    return MealMapper.toDomainList(response.getMeals());
+                });
     }
-    public void getMealsByCategory(String categoryName, ResultCallback<List<Meal>> callback) {
+
+    public Single<List<Meal>> getMealsByCategory(String categoryName) {
         if (categoryName == null || categoryName.trim().isEmpty()) {
-            callback.onError(new IllegalArgumentException("categoryName is required"));
-            return;
+            return Single.error(new IllegalArgumentException("categoryName is required"));
         }
 
         String trimmedCategory = categoryName.trim();
 
-        remote.getMealsByCategoryCall(trimmedCategory).enqueue(new Callback<FilterResultResponseDto>() {
-            @Override
-            public void onResponse(Call<FilterResultResponseDto> call, Response<FilterResultResponseDto> response) {
-                if (response.isSuccessful() && response.body() != null) {
+        return remote.getMealsByCategory(trimmedCategory)
+                .flatMap(response -> {
+                    List<FilterResult> results = FilterResultMapper.toDomainList(response);
 
-                    List<FilterResult> results = FilterResultMapper.toDomainList(response.body());
                     if (results == null || results.isEmpty()) {
-                        callback.onError(new Exception("No meals found for this category."));
-                        return;
+                        return Single.error(new Exception("No meals found for this category."));
                     }
 
                     List<Meal> meals = new ArrayList<>();
@@ -143,17 +90,17 @@ public class HomeRepository {
                         meals.add(m);
                     }
 
-                    callback.onSuccess(meals);
+                    return Single.just(meals);
+                });
+    }
 
-                } else {
-                    callback.onError(new Exception("Request failed: " + response.code()));
-                }
-            }
-
-            @Override
-            public void onFailure(Call<FilterResultResponseDto> call, Throwable t) {
-                callback.onError(new Exception(t));
-            }
-        });
+    public Single<Meal> getMealById(String id) {
+        return remote.getMealById(id)
+                .flatMap(response -> {
+                    if (response == null || response.getMeals() == null || response.getMeals().isEmpty()) {
+                        return Single.error(new Exception("Meal not found"));
+                    }
+                    return Single.just(MealMapper.toDomain(response.getMeals().get(0)));
+                });
     }
 }

--- a/app/src/main/java/com/example/recipe_android_project/features/home/presentation/view/HomeFragment.java
+++ b/app/src/main/java/com/example/recipe_android_project/features/home/presentation/view/HomeFragment.java
@@ -96,7 +96,6 @@ public class HomeFragment extends Fragment implements HomeContract.View, OnMealC
         rvMeals.setAdapter(mealAdapter);
     }
 
-
     private void showFeaturedLoading() {
         if (lottieFeaturedLoading != null) {
             lottieFeaturedLoading.setVisibility(View.VISIBLE);
@@ -117,7 +116,6 @@ public class HomeFragment extends Fragment implements HomeContract.View, OnMealC
             lottieFeaturedLoading.setVisibility(View.GONE);
         }
     }
-
 
     @Override
     public void showScreenLoading() {
@@ -201,23 +199,25 @@ public class HomeFragment extends Fragment implements HomeContract.View, OnMealC
     public void onDestroyView() {
         super.onDestroyView();
 
-        // ✅ cleanup
         Glide.with(this).clear(imgFeatured);
         if (lottieFeaturedLoading != null) lottieFeaturedLoading.cancelAnimation();
         if (lottieScreenLoading != null) lottieScreenLoading.cancelAnimation();
 
-        if (presenter != null) presenter.detach();
+        if (presenter != null) {
+            presenter.detach();
+        }
     }
+
     @Override
-    public void hideMealOfDayLoading() { hideFeaturedLoading(); }
+    public void hideMealOfDayLoading() {
+        hideFeaturedLoading();
+    }
 
     @Override
     public void onMealClick(Meal meal, int position) {
-
     }
 
     @Override
     public void onFavoriteClick(Meal meal, int position, boolean isFavorite) {
-
     }
 }


### PR DESCRIPTION
This commit migrates the home screen's data fetching logic from Retrofit's `Call` callbacks to a reactive pattern using RxJava3. It optimizes concurrent network requests, improves error handling for network-related failures, and ensures robust resource management by integrating disposable tracking.

- **Reactive API & Data Layer**:
    - Updated `MealApiService` to return `Single` observables for all endpoints.
    - Refactored `HomeRemoteDatasource` to utilize RxJava types for meal and category fetching.
    - Updated `HomeRepository` to return `Single` streams, replacing `ResultCallback` interfaces with reactive chains.
    - Implemented mapping logic within `flatMap` and `map` operators to transform DTOs to domain models while handling empty or null responses as errors.

- **Enhanced Presenter Logic**:
    - Transitioned `HomePresenter` to use `CompositeDisposable` for managing the lifecycle of background tasks.
    - Implemented concurrent loading of "Meal of the Day", "Categories", and "Random Meals" using `Schedulers.io()` and `AndroidSchedulers.mainThread()`.
    - Added an `AtomicInteger` counter to track completion of parallel initial requests before hiding the global screen loading state.
    - Introduced `cancelAllRequests()` and `cancelCategoryFilter()` to prevent memory leaks and race conditions when multiple categories are selected rapidly.

- **Error Handling & Resource Management**:
    - Centralized error message resolution in `getErrorMessage()` to provide user-friendly feedback for `UnknownHostException`, `SocketTimeoutException`, and other I/O errors.
    - Standardized cleanup by calling `disposables.clear()` in the presenter's `detach()` / `dispose()` methods.
    - Added a constructor to `HomeRepository` and `HomePresenter` to support dependency injection for better testability.

- **UI & Cleanup**:
    - Standardized loading state management in `HomeFragment`.
    - Removed redundant cleanup logic and unused imports.
    - Ensured `Lottie` animations and `Glide` requests are properly canceled during fragment destruction.